### PR TITLE
Remove storage permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     // Google Stuff //
     implementation 'com.google.android.material:material:1.9.0-alpha02'
     implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'androidx.activity:activity-ktx:1.6.1'
 
     // AndroidX Stuff //
     implementation 'androidx.palette:palette-ktx:1.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/app/src/main/java/com/jamal2367/urlradio/helpers/CollectionHelper.kt
+++ b/app/src/main/java/com/jamal2367/urlradio/helpers/CollectionHelper.kt
@@ -206,18 +206,18 @@ object CollectionHelper {
                 station.smallImage = FileHelper.saveStationImage(
                     context,
                     station.uuid,
-                    tempImageFileUri,
+                    tempImageFileUri.toUri(),
                     Keys.SIZE_STATION_IMAGE_CARD,
                     Keys.STATION_IMAGE_FILE
                 ).toString()
                 station.image = FileHelper.saveStationImage(
                     context,
                     station.uuid,
-                    tempImageFileUri,
+                    tempImageFileUri.toUri(),
                     Keys.SIZE_STATION_IMAGE_MAXIMUM,
                     Keys.STATION_IMAGE_FILE
                 ).toString()
-                station.imageColor = ImageHelper.getMainColor(context, tempImageFileUri)
+                station.imageColor = ImageHelper.getMainColor(context, tempImageFileUri.toUri())
                 station.imageManuallySet = imageManuallySet
             }
         }
@@ -231,7 +231,7 @@ object CollectionHelper {
     fun setStationImageWithStationUuid(
         context: Context,
         collection: Collection,
-        tempImageFileUri: String,
+        tempImageFileUri: Uri,
         stationUuid: String,
         imageManuallySet: Boolean = false
     ): Collection {

--- a/app/src/main/java/com/jamal2367/urlradio/helpers/FileHelper.kt
+++ b/app/src/main/java/com/jamal2367/urlradio/helpers/FileHelper.kt
@@ -190,7 +190,7 @@ object FileHelper {
     fun saveStationImage(
         context: Context,
         stationUuid: String,
-        sourceImageUri: String,
+        sourceImageUri: Uri,
         size: Int,
         fileName: String
     ): Uri {

--- a/app/src/main/java/com/jamal2367/urlradio/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/jamal2367/urlradio/helpers/ImageHelper.kt
@@ -40,9 +40,9 @@ object ImageHelper {
 
 
     /* Get a scaled version of the station image */
-    fun getScaledStationImage(context: Context, imageUriString: String, imageSize: Int): Bitmap {
+    fun getScaledStationImage(context: Context, imageUri: Uri, imageSize: Int): Bitmap {
         val size: Int = (imageSize * getDensityScalingFactor(context)).toInt()
-        return decodeSampledBitmapFromUri(context, imageUriString, size, size)
+        return decodeSampledBitmapFromUri(context, imageUri, size, size)
     }
 
 
@@ -140,7 +140,7 @@ object ImageHelper {
 
 
     /* Extracts color from an image */
-    fun getMainColor(context: Context, imageUri: String): Int {
+    fun getMainColor(context: Context, imageUri: Uri): Int {
         // extract color palette from station image
         val palette: Palette =
             Palette.from(decodeSampledBitmapFromUri(context, imageUri, 72, 72)).generate()
@@ -174,15 +174,13 @@ object ImageHelper {
     /* Return sampled down image for given Uri */
     private fun decodeSampledBitmapFromUri(
         context: Context,
-        imageUriString: String,
+        imageUri: Uri,
         reqWidth: Int,
         reqHeight: Int
     ): Bitmap {
         var bitmap: Bitmap? = null
-        if (imageUriString != Keys.LOCATION_DEFAULT_STATION_IMAGE) {
+        if (imageUri.toString() != Keys.LOCATION_DEFAULT_STATION_IMAGE) {
             try {
-                val imageUri: Uri = imageUriString.toUri()
-
                 // first decode with inJustDecodeBounds=true to check dimensions
                 var stream: InputStream? = context.contentResolver.openInputStream(imageUri)
                 val options = BitmapFactory.Options()

--- a/app/src/main/java/com/jamal2367/urlradio/helpers/ImportHelper.kt
+++ b/app/src/main/java/com/jamal2367/urlradio/helpers/ImportHelper.kt
@@ -15,6 +15,7 @@
 package com.jamal2367.urlradio.helpers
 
 import android.content.Context
+import androidx.core.net.toUri
 import com.jamal2367.urlradio.Keys
 import com.jamal2367.urlradio.core.Collection
 import com.jamal2367.urlradio.core.Station
@@ -55,18 +56,18 @@ object ImportHelper {
                             station.image = FileHelper.saveStationImage(
                                 context,
                                 station.uuid,
-                                sourceImageUri,
+                                sourceImageUri.toUri(),
                                 Keys.SIZE_STATION_IMAGE_CARD,
                                 Keys.STATION_IMAGE_FILE
                             ).toString()
                             station.smallImage = FileHelper.saveStationImage(
                                 context,
                                 station.uuid,
-                                sourceImageUri,
+                                sourceImageUri.toUri(),
                                 Keys.SIZE_STATION_IMAGE_MAXIMUM,
                                 Keys.STATION_IMAGE_FILE
                             ).toString()
-                            station.imageColor = ImageHelper.getMainColor(context, sourceImageUri)
+                            station.imageColor = ImageHelper.getMainColor(context, sourceImageUri.toUri())
                             station.imageManuallySet = true
                         }
                         // improvise a name if empty

--- a/app/src/main/java/com/jamal2367/urlradio/helpers/ShortcutHelper.kt
+++ b/app/src/main/java/com/jamal2367/urlradio/helpers/ShortcutHelper.kt
@@ -22,6 +22,7 @@ import android.widget.Toast
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
+import androidx.core.net.toUri
 import com.jamal2367.urlradio.Keys
 import com.jamal2367.urlradio.MainActivity
 import com.jamal2367.urlradio.R
@@ -71,7 +72,7 @@ object ShortcutHelper {
         stationImageColor: Int
     ): IconCompat {
         val stationImageBitmap: Bitmap =
-            ImageHelper.getScaledStationImage(context, stationImage, 192)
+            ImageHelper.getScaledStationImage(context, stationImage.toUri(), 192)
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             IconCompat.createWithAdaptiveBitmap(
                 ImageHelper.createSquareImage(


### PR DESCRIPTION
First of all, thanks for maintaining such a beautiful MD3 app!

I've wondered why the app requires the permissions `android.permission.WRITE_EXTERNAL_STORAGE` and `android.permission.READ_EXTERNAL_STORAGE`, since it uses the Android Storage Access Framework for m3u exports and backups which does not require any permissions.
I've tested the app (doing backups and restoring them) on SDK 33 and SDK 28 (since that seems to be the last one that required storage write permissions previously), and they worked flawlessly.
Maybe those have been left-overs from the time before the upstream app switched to using SAF?

However, if there's anything left over that needs to be migrated before removing the storage permissions, I wouldn't mind migrating that to SAF too in order to get rid of them.
Cheers